### PR TITLE
Optimized game layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -63,8 +63,9 @@ p {
 
 .Buttons-Container {
   display: flex;
+  gap: 1rem;
+  padding: 1rem;
   width: 100%;
-  gap: 2rem;
 }
 
 .Button {

--- a/src/Components/Game/Game.css
+++ b/src/Components/Game/Game.css
@@ -1,7 +1,11 @@
+.Game {
+  gap: 0;
+  padding: 0;
+}
+
 .Scam-Display {
   background-color: rgb(237, 237, 237);
-  padding: 2rem;
-  border-radius: 0.5rem;
+  padding: 1rem;
   flex: 1;
   width: 100%;
 }

--- a/src/Components/Game/Game.js
+++ b/src/Components/Game/Game.js
@@ -55,7 +55,7 @@ export default function Game() {
 
   return (
     <div className="App">
-      <main className="Container">
+      <main className="Container Game">
         <Header />
         {isModalOpen && (
           <ScamModal closeModal={setModalClose} result={result} />

--- a/src/Components/Game/Game.js
+++ b/src/Components/Game/Game.js
@@ -56,7 +56,11 @@ export default function Game() {
   return (
     <div className="App">
       <main className="Container Game">
+<<<<<<< Updated upstream
         <Header />
+=======
+        <Header score={score} />
+>>>>>>> Stashed changes
         {isModalOpen && (
           <ScamModal closeModal={setModalClose} result={result} />
         )}

--- a/src/Components/Header/Header.css
+++ b/src/Components/Header/Header.css
@@ -1,7 +1,8 @@
 .Header {
-  width: 100%;
   display: flex;
   justify-content: space-between;
+  padding: 1rem;
+  width: 100%;
 }
 
 .Header img {

--- a/src/Components/Header/Header.js
+++ b/src/Components/Header/Header.js
@@ -7,6 +7,7 @@ const Header = () => {
   return (
     <div className="Header">
       <img className="Logo" src={logo} alt="Scam or Not!" />
+      <span>Score: {score}</span>
     </div>
   );
 };

--- a/src/Components/Header/Header.js
+++ b/src/Components/Header/Header.js
@@ -7,13 +7,6 @@ const Header = () => {
   return (
     <div className="Header">
       <img className="Logo" src={logo} alt="Scam or Not!" />
-      <button
-        onClick={() => {
-          navigate("/");
-        }}
-      >
-        Home
-      </button>
     </div>
   );
 };

--- a/src/Components/Question/Question.css
+++ b/src/Components/Question/Question.css
@@ -3,5 +3,5 @@
   padding: 1rem;
   border-radius: 10px;
   width: fit-content;
-  max-width: 60%;
+  max-width: 80%;
 }

--- a/src/Components/Question/Question.css
+++ b/src/Components/Question/Question.css
@@ -2,6 +2,33 @@
   background-color: rgb(217, 217, 217);
   padding: 1rem;
   border-radius: 10px;
-  width: fit-content;
-  max-width: 80%;
+  width: 80%;
+}
+
+.Input {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 70px;
+  left: 0;
+  bottom: 0;
+  background-color: rgb(235, 235, 235);
+  padding: 1rem;
+  text-align: center;
+  gap: 1rem;
+}
+
+.Input-TextBox {
+  background-color: white;
+  width: 100%;
+  height: 100%;
+  border-radius: 20px;
+}
+
+.Input-Send {
+  background-color: rgb(255, 255, 255);
+  height: 100%;
+  aspect-ratio: 1/1;
+  border-radius: 20px;
 }

--- a/src/Components/Question/Question.js
+++ b/src/Components/Question/Question.js
@@ -1,5 +1,18 @@
 import "./Question.css";
 
-export default function Question({ content }) {
-  return <div className="Question">{content}</div>;
+export default function Question({ content, sender }) {
+  return (
+    <div className="Pseudo-Phone">
+      <div className="CallerID">
+        <h4>{sender}</h4>
+      </div>
+      <div className="Messages">
+        <div className="Question">{content}</div>
+      </div>
+      <div className="Input">
+        <div className="Input-TextBox"></div>
+        <div className="Input-Send"></div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
This change optimizes the use of the screen real estate for the game itself, to ensure it can play on smaller screens (e.g. iPhone SE) and text doesn't overflow or get truncated.

It also removes the "home" button, as this is an anti-flow. We want people to go from the home screen to playing the game, not the other way around. Once in the game, the goal is to get them to complete it and share. 🙂 

**Before:**

<img width="443" alt="Screenshot 2023-06-20 at 5 15 00 PM" src="https://github.com/hengmhs/build-for-good/assets/5259935/99c527cb-eeb6-4824-99b5-d79ed9c1f51e">
<img width="470" alt="Screenshot 2023-06-20 at 5 14 48 PM" src="https://github.com/hengmhs/build-for-good/assets/5259935/ecd6cc7e-d5d3-4b84-97de-84436d7a44c3">


**After:**

<img width="443" alt="Screenshot 2023-06-20 at 5 15 34 PM" src="https://github.com/hengmhs/build-for-good/assets/5259935/97ad99cf-fe9c-4b28-82e2-cbe7437b76a3">
<img width="452" alt="Screenshot 2023-06-20 at 5 15 23 PM" src="https://github.com/hengmhs/build-for-good/assets/5259935/921cb012-f954-4ea3-9bad-d60f570adf97">
