### PR TITLE
Optimize game layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -65,7 +65,8 @@ p {
 .Buttons-Container {
   display: flex;
   width: 100%;
-  gap: 2rem;
+  gap: 1rem;
+  padding: 1rem;
 }
 
 .Button {

--- a/src/Components/Game/Game.css
+++ b/src/Components/Game/Game.css
@@ -1,3 +1,8 @@
+.Game {
+  padding: 0;
+  gap: 0;
+}
+
 .Scam-Display {
   width: 100%;
   height: 100%;

--- a/src/Components/Game/Game.js
+++ b/src/Components/Game/Game.js
@@ -57,7 +57,7 @@ export default function Game() {
 
   return (
     <div className="App">
-      <main className="Container">
+      <main className="Container Game">
         <Header score={score} />
         {isModalOpen && (
           <ScamModal closeModal={setModalClose} result={result} score={score} />

--- a/src/Components/Header/Header.css
+++ b/src/Components/Header/Header.css
@@ -2,6 +2,7 @@
   width: 100%;
   display: flex;
   justify-content: space-between;
+  padding: 1rem;
 }
 
 .Header img {

--- a/src/Components/Header/Header.css
+++ b/src/Components/Header/Header.css
@@ -5,6 +5,6 @@
 }
 
 .Header img {
-  height: 35px;
+  height: 25px;
   width: auto;
 }

--- a/src/Components/Header/Header.js
+++ b/src/Components/Header/Header.js
@@ -8,13 +8,6 @@ const Header = ({ score }) => {
     <div className="Header">
       <img className="Logo" src={logo} alt="Scam or Not!" />
       <span>Score: {score}</span>
-      <button
-        onClick={() => {
-          navigate("/");
-        }}
-      >
-        Home
-      </button>
     </div>
   );
 };

--- a/src/Components/Question/Question.css
+++ b/src/Components/Question/Question.css
@@ -1,39 +1,36 @@
 .Pseudo-Phone {
-  position: relative;
   background-color: rgb(246, 246, 246);
-  padding: 1.5rem;
-  padding-top: 6rem;
-  border-radius: 2rem;
+  display: flex;
+  flex-direction: column;
   flex: 1;
-  max-width: 450px;
   width: 100%;
-  max-height: 800px;
   height: 100%;
   overflow: hidden;
 }
 
 .CallerID {
-  position: absolute;
   width: 100%;
   height: 70px;
-  left: 0;
-  top: 0;
   background-color: rgb(235, 235, 235);
   padding: 1rem;
   text-align: center;
   border-bottom: 1px solid grey;
 }
 
+.Messages {
+  flex-grow: 1;
+}
+
 .Question {
   background-color: rgb(217, 217, 217);
   padding: 1rem;
+  margin: 1rem;
   border-radius: 10px;
   width: fit-content;
   width: 80%;
 }
 
 .Input {
-  position: absolute;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/Components/Question/Question.js
+++ b/src/Components/Question/Question.js
@@ -6,7 +6,9 @@ export default function Question({ content, sender }) {
       <div className="CallerID">
         <h4>{sender}</h4>
       </div>
-      <div className="Question">{content}</div>
+      <div className="Messages">
+        <div className="Question">{content}</div>
+      </div>
       <div className="Input">
         <div className="Input-TextBox"></div>
         <div className="Input-Send"></div>


### PR DESCRIPTION
This change optimizes the game layout a bit so that it can fit on small phones, and avoid any overflow or breaking of text. It also removes the home button, since it's a bit of an anti-flow. We want people to go from the home screen to play the game, not the other way around. 🙂 

**After:**

<img width="446" alt="Screenshot 2023-06-20 at 5 52 18 PM" src="https://github.com/hengmhs/build-for-good/assets/5259935/2237d15a-718c-40c8-bf50-77ceb591f969">
